### PR TITLE
Bump compat (CategoricalArrays, DataFrames, RData)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RDatasets"
 uuid = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
-version = "0.6.7"
+version = "0.6.8"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/Project.toml
+++ b/Project.toml
@@ -12,11 +12,11 @@ RData = "df47a6cb-8c03-5eed-afd8-b6050d6c41da"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-CSV = "0.5, 0.6"
+CSV = "0.6.2"
 CodecZlib = "0.4, 0.5, 0.6, 0.7"
-DataFrames = "0.15, 0.16, 0.17, 0.18, 0.19, 0.20"
+DataFrames = "0.21"
 FileIO = "1"
-RData = "0.5, 0.6, 0.7"
+RData = "0.7.3"
 Reexport = "0.2"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ CSV = "0.6.2"
 CodecZlib = "0.4, 0.5, 0.6, 0.7"
 DataFrames = "0.21"
 FileIO = "1"
-RData = "0.7.3"
+RData = "0.7.2"
 Reexport = "0.2"
 julia = "1"
 


### PR DESCRIPTION
One test is failing.

```julia
using RDatasets
dataset("COUNT", "fasttrakg")
```
gives an
```
ArgumentError: Duplicate entries are not allowed in levels
handle_error(::ArgumentError, ::FileIO.File{FileIO.DataFormat{:RData}}) at error_handling.jl:82
handle_exceptions(::Array{Any,1}, ::String) at error_handling.jl:77
load(::FileIO.Formatted; options::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at loadsave.jl:189
load at loadsave.jl:169 [inlined]
#load#13 at loadsave.jl:118 [inlined]
load at loadsave.jl:118 [inlined]
dataset(::String, ::String) at dataset.jl:12
top-level scope at tmp.jl:3
```

I wonder if this must be fixed in RData due to changes in CategoricalArrays?