### PR TITLE
Specify file format explicitly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RDatasets"
 uuid = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
-version = "0.7.4"
+version = "0.7.5"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,6 @@ CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 RData = "df47a6cb-8c03-5eed-afd8-b6050d6c41da"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 

--- a/src/RDatasets.jl
+++ b/src/RDatasets.jl
@@ -3,7 +3,7 @@ module RDatasets
         @eval Base.Experimental.@optlevel 1
     end
 
-    using Reexport, RData, CSV, CodecZlib
+    using Reexport, FileIO, CSV, CodecZlib
     @reexport using DataFrames
 
     export dataset

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -9,7 +9,7 @@ function dataset(package_name::AbstractString, dataset_name::AbstractString)
 
     rdaname = joinpath(basename, string(dataset_name, ".rda"))
     if isfile(rdaname)
-        return load(rdaname)[dataset_name]
+        return load(File{format"RData"}(rdaname))[dataset_name]
     end
 
     csvname = joinpath(basename, string(dataset_name, ".csv.gz"))

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -9,7 +9,13 @@ function dataset(package_name::AbstractString, dataset_name::AbstractString)
 
     rdaname = joinpath(basename, string(dataset_name, ".rda"))
     if isfile(rdaname)
-        return load(File{format"RData"}(rdaname))[dataset_name]
+        if isdefined(FileIO, :action)
+            # FileIO >= 1.6
+            return load(File{format"RData"}(rdaname))[dataset_name]
+        else
+            # FileIO < 1.6
+            return load(File(format"RData", rdaname))[dataset_name]
+        end
     end
 
     csvname = joinpath(basename, string(dataset_name, ".csv.gz"))


### PR DESCRIPTION
This PR fixes https://github.com/JuliaStats/RDatasets.jl/issues/117 - and does not seem to break the tests. It specifies the file format explicitly when loading ".rda" files instead of relying on the automatic discovery in FileIO. This PR is an alternative to https://github.com/JuliaStats/RDatasets.jl/pull/118.

@timholy My guess is that FileIO 1.6 changed the query mechanism. It seems it prioritized the file ending in FileIO <= 1.5 but with FileIO 1.6 the file type is determined incorrectly as Gzip due to the magic bytes of compressed RData files.